### PR TITLE
Implement Copt LP Algo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,3 +5,4 @@ them in reverse chronological order.
 
 
 ## x.x.x - 2023-xx-xx
+- #26 Implements COPT LP optimizer

--- a/environment.yml
+++ b/environment.yml
@@ -26,4 +26,4 @@ dependencies:
   - snakeviz
   - statsmodels
   - toml
-  - pip: [-e ., kaleido==0.1.0.post1, pdbp]
+  - pip: [-e ., kaleido==0.1.0.post1, pdbp, coptpy]

--- a/src/pyvmte/identification/identification.py
+++ b/src/pyvmte/identification/identification.py
@@ -187,7 +187,7 @@ def _solve_lp(lp_inputs: dict, max_or_min: str, method: str) -> float:
     a_eq = lp_inputs["a_eq"]
 
     if method == "copt":
-        return _solve_lp_copt(c, a_eq, b_eq, max_or_min)
+        return _solve_lp_copt(c, a_eq, b_eq)
 
     return linprog(c, A_eq=a_eq, b_eq=b_eq, bounds=(0, 1)).fun
 
@@ -248,7 +248,6 @@ def _solve_lp_copt(
     c: np.ndarray,
     a_eq: np.ndarray,
     b_eq: np.ndarray,
-    max_or_min: str,
 ) -> float:
     """Wrapper for solving LP using copt algorithm."""
     env = cp.Envr()

--- a/src/pyvmte/identification/identification.py
+++ b/src/pyvmte/identification/identification.py
@@ -1,10 +1,11 @@
 """Function for identification."""
 from collections.abc import Callable
 
+import coptpy as cp  # type: ignore
 import numpy as np
 import pandas as pd  # type: ignore
-from scipy.optimize import (
-    OptimizeResult,  # type: ignore
+from coptpy import COPT
+from scipy.optimize import (  # type: ignore
     linprog,  # type: ignore
 )
 
@@ -23,6 +24,7 @@ def identification(
     m1_dgp: Callable,
     instrument: Instrument,
     u_partition: np.ndarray,
+    method: str = "highs",
 ):
     """Compute bounds on target estimand given identified estimands and DGP.
 
@@ -38,13 +40,23 @@ def identification(
         instrument (dict): Dictionary containing all information about the instrument.
         u_partition (list or np.array, optional): Partition of u for basis_funcs.
             Defaults to None.
+        method (str, optional): Method for solving the linear program.
+            Implemented are: all methods supported by scipy.linprog as well as copt.
+            Defaults to "highs" using scipy.linprog.
 
     Returns:
         dict: A dictionary containing the upper and lower bound of the target estimand.
 
     """
+    # ==================================================================================
+    # Perform some additional checks on arguments
+    # ==================================================================================
     if isinstance(identified_estimands, dict):
         identified_estimands = [identified_estimands]
+
+    # ==================================================================================
+    # Generate linear program inputs
+    # ==================================================================================
 
     lp_inputs = {}
 
@@ -62,8 +74,12 @@ def identification(
         instrument=instrument,
     )
 
-    upper_bound = (-1) * _solve_lp(lp_inputs, "max").fun
-    lower_bound = _solve_lp(lp_inputs, "min").fun
+    # ==================================================================================
+    # Solve linear program
+    # ==================================================================================
+
+    upper_bound = (-1) * _solve_lp(lp_inputs, "max", method=method)
+    lower_bound = _solve_lp(lp_inputs, "min", method=method)
 
     return {"upper_bound": upper_bound, "lower_bound": lower_bound}
 
@@ -163,14 +179,17 @@ def _compute_equality_constraint_matrix(
     return np.array(c_matrix)
 
 
-def _solve_lp(lp_inputs: dict, max_or_min: str) -> OptimizeResult:
-    """Solve the linear program."""
+def _solve_lp(lp_inputs: dict, max_or_min: str, method: str) -> float:
+    """Wrapper for solving the linear program."""
     c = np.array(lp_inputs["c"]) if max_or_min == "min" else -np.array(lp_inputs["c"])
 
     b_eq = lp_inputs["b_eq"]
     a_eq = lp_inputs["a_eq"]
 
-    return linprog(c, A_eq=a_eq, b_eq=b_eq, bounds=(0, 1))
+    if method == "copt":
+        return _solve_lp_copt(c, a_eq, b_eq, max_or_min)
+
+    return linprog(c, A_eq=a_eq, b_eq=b_eq, bounds=(0, 1)).fun
 
 
 def _compute_moments_for_weights(target: Estimand, instrument: Instrument) -> dict:
@@ -223,3 +242,23 @@ def _compute_covariance_dz(
     ed = pscore_z @ pdf_z
     edz = np.sum(support_z * pscore_z * pdf_z)
     return edz - ed * ez
+
+
+def _solve_lp_copt(
+    c: np.ndarray,
+    a_eq: np.ndarray,
+    b_eq: np.ndarray,
+    max_or_min: str,
+) -> float:
+    """Wrapper for solving LP using copt algorithm."""
+    env = cp.Envr()
+    model = env.createModel("identification")
+    x = model.addMVar(len(c), nameprefix="x", lb=0, ub=1)
+    model.setObjective(c @ x, COPT.MINIMIZE)
+    model.addMConstr(a_eq, x, "E", b_eq, nameprefix="c")
+    model.solveLP()
+
+    if model.status != COPT.OPTIMAL:
+        msg = "LP not solved to optimality by copt."
+        raise ValueError(msg)
+    return model.objval

--- a/src/pyvmte/profiling/profile_estimation.py
+++ b/src/pyvmte/profiling/profile_estimation.py
@@ -18,3 +18,5 @@ z_data = np.array(data["z"])
 
 target = setup.target
 identified_estimands = setup.identified_estimands
+
+basis_func_type = "constant"

--- a/src/pyvmte/profiling/profile_identification.py
+++ b/src/pyvmte/profiling/profile_identification.py
@@ -1,0 +1,16 @@
+"""Setup for profiling identification function."""
+from pyvmte.config import IV_PAPER, SETUP_FIG5
+from pyvmte.estimation.estimation import _compute_u_partition, _generate_basis_funcs
+from pyvmte.utilities import load_paper_dgp
+
+DGP = load_paper_dgp()
+
+u_partition = _compute_u_partition(target=SETUP_FIG5.target, pscore_z=IV_PAPER.pscores)
+bfuncs = _generate_basis_funcs("constant", u_partition=u_partition)
+
+target = SETUP_FIG5.target
+identified_estimands = SETUP_FIG5.identified_estimands
+basis_funcs = bfuncs
+m0_dgp = DGP["m0"]
+m1_dgp = DGP["m1"]
+instrument = IV_PAPER

--- a/src/pyvmte/profiling/profile_lp_algos_estimation.py
+++ b/src/pyvmte/profiling/profile_lp_algos_estimation.py
@@ -1,0 +1,16 @@
+"""Setup profiling for comparing LP algos."""
+import numpy as np
+
+from pyvmte.config import SETUP_FIG3
+from pyvmte.utilities import simulate_data_from_paper_dgp
+
+target = SETUP_FIG3.target
+identified_estimands = SETUP_FIG3.identified_estimands
+basis_func_type = "constant"
+
+rng = np.random.default_rng()
+
+data = simulate_data_from_paper_dgp(10_000, rng)
+y_data = data["y"]
+d_data = data["d"]
+z_data = data["z"]

--- a/src/pyvmte/simulation/simulation_funcs.py
+++ b/src/pyvmte/simulation/simulation_funcs.py
@@ -16,6 +16,7 @@ def monte_carlo_pyvmte(
     rng: np.random.Generator,
     tolerance: float | None = None,
     lp_outputs: bool = False,  # noqa: FBT001, FBT002
+    method: str = "highs",
 ) -> dict:
     """Run monte carlo simulation using pyvmte module."""
     upper_bounds = np.zeros(repetitions)
@@ -45,6 +46,7 @@ def monte_carlo_pyvmte(
             tolerance,
             x_data=None,
             u_partition=None,
+            method=method,
         )
 
         upper_bounds[rep] = results["upper_bound"]

--- a/src/pyvmte/utilities.py
+++ b/src/pyvmte/utilities.py
@@ -1,6 +1,7 @@
 """Utilities used in various parts of the project."""
-
+import contextlib
 import math
+import os
 from collections.abc import Callable
 
 import numpy as np
@@ -549,3 +550,10 @@ def _check_estimation_arguments(
 
 class EstimationArgumentError(Exception):
     """Raised when arguments to estimation function are not valid."""
+
+
+@contextlib.contextmanager
+def suppress_print():
+    """Suppress print statements in context."""
+    with open(os.devnull, "w") as f, contextlib.redirect_stdout(f):  # noqa: PTH123
+        yield

--- a/tests/estimation/test_estimate_paper_bounds.py
+++ b/tests/estimation/test_estimate_paper_bounds.py
@@ -12,11 +12,25 @@ NUM_SIMULATIONS = 250
 
 
 @pytest.mark.parametrize(
-    "setup",
-    [(SETUP_FIG2), (SETUP_FIG3), (SETUP_FIG5)],
-    ids=["fig2", "fig3", "fig5"],
+    ("setup", "method"),
+    [
+        (SETUP_FIG2, "highs"),
+        (SETUP_FIG3, "highs"),
+        (SETUP_FIG5, "highs"),
+        (SETUP_FIG2, "copt"),
+        (SETUP_FIG3, "copt"),
+        (SETUP_FIG5, "copt"),
+    ],
+    ids=[
+        "fig2_highs",
+        "fig3_highs",
+        "fig5_highs",
+        "fig2_copt",
+        "fig3_copt",
+        "fig5_copt",
+    ],
 )
-def test_consistently_estimate_figure_bounds(setup: Setup):
+def test_consistently_estimate_figure_bounds(setup: Setup, method: str):
     expected = [setup.lower_bound, setup.upper_bound]
 
     results = monte_carlo_pyvmte(
@@ -27,6 +41,7 @@ def test_consistently_estimate_figure_bounds(setup: Setup):
         basis_func_type="constant",
         tolerance=1 / SAMPLE_SIZE,
         rng=RNG,
+        method=method,
     )
 
     mean_upper_bound = np.mean(results["upper_bounds"])

--- a/tests/estimation/test_estimation_funcs.py
+++ b/tests/estimation/test_estimation_funcs.py
@@ -155,6 +155,7 @@ def test_first_step_linear_program_runs_and_non_zero():
         data=data,
         beta_hat=beta_hat,
         instrument=instrument,
+        method="highs",
     )
 
     assert result["minimal_deviations"] != 0
@@ -243,6 +244,7 @@ def test_second_step_linear_program_runs():
         tolerance=tolerance,
         beta_hat=beta_hat,
         instrument=instrument,
+        method="highs",
     )
 
     assert result is not None

--- a/tests/identification/test_identification_paper_figs.py
+++ b/tests/identification/test_identification_paper_figs.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from pyvmte.config import (
     SETUP_FIG2,
@@ -18,7 +19,7 @@ INSTRUMENT = Instrument(
     pscores=DGP["pscores"],
 )
 
-U_PART = [0, 0.35, 0.6, 0.7, 0.9, 1]
+U_PART = np.array([0, 0.35, 0.6, 0.7, 0.9, 1])
 
 BFUNC1 = {"type": "constant", "u_lo": 0.0, "u_hi": 0.35}
 BFUNC2 = {"type": "constant", "u_lo": 0.35, "u_hi": 0.6}
@@ -55,11 +56,25 @@ def test_paper_late_ols_iv():
 
 
 @pytest.mark.parametrize(
-    "setup",
-    [(SETUP_FIG2), (SETUP_FIG3), (SETUP_FIG5)],
-    ids=["fig2", "fig3", "fig5"],
+    ("setup", "method"),
+    [
+        (SETUP_FIG2, "highs"),
+        (SETUP_FIG3, "highs"),
+        (SETUP_FIG5, "highs"),
+        (SETUP_FIG2, "copt"),
+        (SETUP_FIG3, "copt"),
+        (SETUP_FIG5, "copt"),
+    ],
+    ids=[
+        "fig2_highs",
+        "fig3_highs",
+        "fig5_highs",
+        "fig2_copt",
+        "fig3_copt",
+        "fig5_copt",
+    ],
 )
-def test_identification_paper_bounds(setup: Setup):
+def test_identification_paper_bounds(setup: Setup, method: str):
     expected = [setup.lower_bound, setup.upper_bound]
 
     target_estimand = setup.target
@@ -73,6 +88,7 @@ def test_identification_paper_bounds(setup: Setup):
         m1_dgp=DGP["m1"],
         u_partition=U_PART,
         instrument=INSTRUMENT,
+        method=method,
     )
 
     actual = [result["lower_bound"], result["upper_bound"]]


### PR DESCRIPTION
#### Changes

This PR implements the Copt LP algo, partly adressing #25. Copt might be faster for large scale problems/more complicated settings, although in the current applications I find that the scipy LP High-GS implementation is faster (probably due to overhead when using the Copt API).

Closes #25 

#### TODO (@buddejul):

- [ ] Document PR in docs/changes.rst.
