### PR TITLE
Inference via resampling procedures

### DIFF
--- a/src/pyvmte/classes.py
+++ b/src/pyvmte/classes.py
@@ -167,6 +167,9 @@ class PyvmteResult(NamedTuple):
             Estimation only.
         first_lp_inputs: Inputs to the first step LP. Estimation only.
         first_optres: Results of the first step LP. Estimation only.
+        ci_lower: Lower bound of the confidence interval. Estimation only.
+        ci_upper: Upper bound of the confidence interval. Estimation only.
+        confidence_interval: Type of confidence interval. Estimation only.
 
     """
 
@@ -188,3 +191,6 @@ class PyvmteResult(NamedTuple):
     first_minimal_deviations: float | None = None
     first_lp_inputs: dict | None = None
     first_optres: OptimizeResult | None = None
+    ci_lower: float | None = None
+    ci_upper: float | None = None
+    confidence_interval: str | None = None

--- a/src/pyvmte/estimation/estimation.py
+++ b/src/pyvmte/estimation/estimation.py
@@ -14,6 +14,7 @@ from scipy.optimize import (  # type: ignore
 from pyvmte.classes import Estimand, Instrument, PyvmteResult
 from pyvmte.identification.identification import _compute_choice_weights
 from pyvmte.utilities import (
+    _error_report_confidence_interval,
     _error_report_estimand,
     _error_report_estimation_data,
     _error_report_invalid_basis_func_type,
@@ -48,6 +49,7 @@ def estimation(
     monotone_response: str | None = None,
     method: str = "highs",
     basis_func_options: dict | None = None,
+    confidence_interval: str | None = None,
 ) -> PyvmteResult:
     """Estimate bounds given target, identified estimands, and data (estimation).
 
@@ -71,6 +73,9 @@ def estimation(
             Defaults to None, allowed are "positive" and "negative".
         method (str, optional): Method for scipy linprog solver. Default highs.
         basis_func_options: Options for basis functions. Default None.
+        confidence_interval: Confidence interval for true parameter. Currently only
+            the non-parametric bootstrap is supported. Default is to not perform any
+            inference.
 
     Returns:
         PyvmteResult: Object containing the results of the estimation procedure.
@@ -93,6 +98,7 @@ def estimation(
         basis_func_options=basis_func_options,
         mte_monotone=mte_monotone,
         monotone_response=monotone_response,
+        confidence_interval=confidence_interval,
     )
 
     # ==================================================================================
@@ -1083,6 +1089,7 @@ def _check_estimation_arguments(
     monotone_response: str | None,
     method: str,
     basis_func_options: dict | None,
+    confidence_interval: str | None,
 ):
     """Check args to estimation func, returns report if there are errors."""
     error_report = ""
@@ -1104,6 +1111,7 @@ def _check_estimation_arguments(
     error_report += _error_report_shape_constraints(shape_constraints)
     error_report += _error_report_mte_monotone(mte_monotone)
     error_report += _error_report_monotone_response(monotone_response)
+    error_report += _error_report_confidence_interval(confidence_interval)
 
     if error_report != "":
         raise ValueError(error_report)

--- a/src/pyvmte/estimation/estimation.py
+++ b/src/pyvmte/estimation/estimation.py
@@ -1196,7 +1196,7 @@ def _compute_confidence_interval(
         "basis_func_options": basis_func_options,
     }
 
-    _resampling_methods = ["bootstrap", "subsampling", "recentered_bootstrap"]
+    _resampling_methods = ["bootstrap", "subsampling", "rescaled_bootstrap"]
 
     if confidence_interval in _resampling_methods:
         return _compute_resampling_interval(
@@ -1232,7 +1232,7 @@ def _compute_resampling_interval(
         n_resamples = confidence_interval_options["n_boot"]
         resample_size = n_obs
 
-    if confidence_interval in ["recentered_bootstrap", "subsampling"]:
+    if confidence_interval in ["rescaled_bootstrap", "subsampling"]:
         if callable(confidence_interval_options["subsample_size"]):
             resample_size = int(
                 np.floor(confidence_interval_options["subsample_size"](n_obs)),
@@ -1241,7 +1241,7 @@ def _compute_resampling_interval(
         else:
             resample_size = confidence_interval_options["subsample_size"]
 
-    if confidence_interval == "recentered_bootstrap":
+    if confidence_interval == "rescaled_bootstrap":
         n_resamples = confidence_interval_options["n_boot"]
 
     if confidence_interval == "subsampling":

--- a/src/pyvmte/estimation/estimation.py
+++ b/src/pyvmte/estimation/estimation.py
@@ -218,6 +218,24 @@ def estimation(
         _success_lower = results_second_step["scipy_return_lower"].success
         _success_upper = results_second_step["scipy_return_upper"].success
 
+    if confidence_interval is not None:
+        ci_lower, ci_upper = _compute_confidence_interval(
+            target=target,
+            identified_estimands=identified_estimands,
+            basis_func_type=basis_func_type,
+            y_data=y_data,
+            z_data=z_data,
+            d_data=d_data,
+            tolerance=tolerance,
+            u_partition=u_partition,
+            shape_constraints=shape_constraints,
+            mte_monotone=mte_monotone,
+            monotone_response=monotone_response,
+            method=method,
+            basis_func_options=basis_func_options,
+            confidence_interval=confidence_interval,
+        )
+
     return PyvmteResult(
         procedure="estimation",
         success=(_success_lower, _success_upper),
@@ -245,6 +263,9 @@ def estimation(
             "mte_monotone": mte_monotone,
             "monotone_response": monotone_response,
         },
+        ci_lower=ci_lower if confidence_interval is not None else None,
+        ci_upper=ci_upper if confidence_interval is not None else None,
+        confidence_interval=confidence_interval,
     )
 
 
@@ -1115,3 +1136,24 @@ def _check_estimation_arguments(
 
     if error_report != "":
         raise ValueError(error_report)
+
+
+def _compute_confidence_interval(
+    target: Estimand,
+    identified_estimands: list[Estimand],
+    basis_func_type: str,
+    y_data: np.ndarray,
+    z_data: np.ndarray,
+    d_data: np.ndarray,
+    tolerance: float | None = None,
+    u_partition: np.ndarray | None = None,
+    shape_constraints: tuple[str, str] | None = None,
+    mte_monotone: str | None = None,
+    monotone_response: str | None = None,
+    method: str = "highs",
+    basis_func_options: dict | None = None,
+    confidence_interval: str | None = None,
+    alpha: float = 0.05,
+):
+    """Compute confidence interval for the target parameter."""
+    return -1, 1

--- a/src/pyvmte/estimation/estimation_kwargs.py
+++ b/src/pyvmte/estimation/estimation_kwargs.py
@@ -1,0 +1,35 @@
+"""Standard estimation kwargs."""
+
+
+from pyvmte.classes import Estimand
+from pyvmte.config import RNG
+from pyvmte.utilities import simulate_data_from_simple_model_dgp
+
+dgp_params = {
+    "y1_at": 1,
+    "y0_at": 0,
+    "y1_c": 0.5,
+    "y0_c": 0,
+    "y1_nt": 1,  # ensures we are at the upper bound of the identified set
+    "y0_nt": 0,
+}
+
+data = simulate_data_from_simple_model_dgp(
+    sample_size=10_000,
+    rng=RNG,
+    dgp_params=dgp_params,
+)
+KWARGS_EST = {
+    "target": Estimand("late", u_hi_extra=0.2),
+    "identified_estimands": [
+        Estimand(
+            "late",
+        ),
+    ],
+    "basis_func_type": "constant",
+    "y_data": data["y"],
+    "z_data": data["z"],
+    "d_data": data["d"],
+    "confidence_interval": "bootstrap",
+    "confidence_interval_options": {"n_boot": 100, "alpha": 0.05},
+}

--- a/src/pyvmte/estimation/profile_estimation_confidence_interval.py
+++ b/src/pyvmte/estimation/profile_estimation_confidence_interval.py
@@ -1,0 +1,34 @@
+"""Profile Estimation Confidence Interval."""
+
+
+from pyvmte.classes import Estimand
+from pyvmte.config import RNG
+from pyvmte.utilities import simulate_data_from_simple_model_dgp
+
+dgp_params = {
+    "y1_at": 1,
+    "y0_at": 0,
+    "y1_c": 0.5,
+    "y0_c": 0,
+    "y1_nt": 1,  # ensures we are at the upper bound of the identified set
+    "y0_nt": 0,
+}
+
+data = simulate_data_from_simple_model_dgp(
+    sample_size=10_000,
+    rng=RNG,
+    dgp_params=dgp_params,
+)
+kwargs = {
+    "target": Estimand("late", u_hi_extra=0.2),
+    "identified_estimands": [
+        Estimand(
+            "late",
+        ),
+    ],
+    "basis_func_type": "constant",
+    "y_data": data["y"],
+    "z_data": data["z"],
+    "d_data": data["d"],
+    "confidence_interval": "bootstrap",
+}

--- a/src/pyvmte/identification/identification_kwargs.py
+++ b/src/pyvmte/identification/identification_kwargs.py
@@ -1,0 +1,33 @@
+"""Identification kwargs for MST Figure 7."""
+
+from pyvmte.config import (
+    IV_MST,
+    SETUP_FIG7,
+    SETUP_SM_SHARP,
+    U_PART_MST,
+    _m0_paper,
+    _m1_paper,
+)
+from pyvmte.utilities import generate_bernstein_basis_funcs
+
+basis_funcs = generate_bernstein_basis_funcs(k=9)
+
+
+KWARGS_ID = {
+    "target": SETUP_FIG7.target,
+    "identified_estimands": SETUP_FIG7.identified_estimands,
+    "basis_funcs": basis_funcs,
+    "m0_dgp": _m0_paper,
+    "m1_dgp": _m1_paper,
+    "instrument": IV_MST,
+    "u_partition": U_PART_MST,
+    "shape_constraints": SETUP_FIG7.shape_constraints,
+    "mte_monotone": None,
+    "monotone_response": None,
+}
+
+
+KWARGS_ID_SM_SHARP = {
+    "target": SETUP_SM_SHARP.target,
+    "identified_estimands": SETUP_SM_SHARP.identified_estimands,
+}

--- a/src/pyvmte/utilities.py
+++ b/src/pyvmte/utilities.py
@@ -14,6 +14,8 @@ from scipy.interpolate import BPoly  # type: ignore[import-untyped]
 
 from pyvmte.classes import Bern, Estimand, Instrument, PyvmteResult
 
+supported_confidence_intervals = ["bootstrap", "subsampling", "rescaled_bootstrap"]
+
 
 def compute_moments(supp_z, f_z, prop_z):
     """Calculate E[z], E[d], E[dz], Cov[d,z] for a discrete instrument z and binary d.
@@ -471,12 +473,10 @@ def _error_report_confidence_interval(confidence_interval: str | None) -> str:
             "but not of type str."
         )
 
-    _supported_procedures = ["bootstrap", "subsampling", "recentered_bootstrap"]
-
-    if confidence_interval not in _supported_procedures:
+    if confidence_interval not in supported_confidence_intervals:
         error_report += (
             f"Confidence interval procedure {confidence_interval} is not valid. "
-            f"Only {_supported_procedures} are valid."
+            f"Only {supported_confidence_intervals} are valid."
         )
 
     return error_report
@@ -488,18 +488,18 @@ def _error_report_confidence_interval_options(
 ) -> str:
     error_report = ""
 
-    if confidence_interval is None:
+    if confidence_interval not in supported_confidence_intervals:
         return error_report
 
     required_keys = {
         "bootstrap": ["n_boot", "alpha"],
         "subsampling": ["n_subsamples", "subsample_size", "alpha"],
-        "recentered_bootstrap": ["n_boot", "subsample_size", "alpha"],
+        "rescaled_bootstrap": ["n_boot", "subsample_size", "alpha"],
     }
 
     # Check if confidence_interval_options is a dict with required keys
     # if not, return error message
-    if confidence_interval is not None and confidence_interval_options is None:
+    if confidence_interval_options is None:
         error_report += (
             f"Confidence interval options - dict with keys"
             " {required_keys[confidence_interval]} are missing "

--- a/src/pyvmte/utilities.py
+++ b/src/pyvmte/utilities.py
@@ -482,6 +482,37 @@ def _error_report_confidence_interval(confidence_interval: str | None) -> str:
     return error_report
 
 
+def _error_report_confidence_interval_options(
+    confidence_interval: str | None,
+    confidence_interval_options: dict | None,
+) -> str:
+    error_report = ""
+
+    if confidence_interval is None:
+        return error_report
+
+    required_keys = ["n_boot", "alpha"]
+
+    # Check if confidence_interval_options is a dict with required keys
+    # if not, return error message
+    if confidence_interval is not None and confidence_interval_options is None:
+        error_report += (
+            f"Confidence interval options - dict with keys {required_keys} are missing "
+            " for confidence interval procedure "
+            f"{confidence_interval}."
+        )
+
+    if not isinstance(confidence_interval_options, dict) or (
+        not all(key in confidence_interval_options for key in required_keys)
+    ):
+        error_report += (
+            f"Confidence interval options {confidence_interval_options} is not a dict "
+            f"with required keys {required_keys}."
+        )
+
+    return error_report
+
+
 def generate_bernstein_basis_funcs(k: int) -> list[dict]:
     """Generate list containing basis functions of kth-oder Bernstein polynomial.
 

--- a/src/pyvmte/utilities.py
+++ b/src/pyvmte/utilities.py
@@ -471,7 +471,7 @@ def _error_report_confidence_interval(confidence_interval: str | None) -> str:
             "but not of type str."
         )
 
-    _supported_procedures = "bootstrap"
+    _supported_procedures = ["bootstrap", "subsampling", "recentered_bootstrap"]
 
     if confidence_interval not in _supported_procedures:
         error_report += (
@@ -491,24 +491,36 @@ def _error_report_confidence_interval_options(
     if confidence_interval is None:
         return error_report
 
-    required_keys = ["n_boot", "alpha"]
+    required_keys = {
+        "bootstrap": ["n_boot", "alpha"],
+        "subsampling": ["n_subsamples", "subsample_size", "alpha"],
+        "recentered_bootstrap": ["n_boot", "subsample_size", "alpha"],
+    }
 
     # Check if confidence_interval_options is a dict with required keys
     # if not, return error message
     if confidence_interval is not None and confidence_interval_options is None:
         error_report += (
-            f"Confidence interval options - dict with keys {required_keys} are missing "
+            f"Confidence interval options - dict with keys"
+            " {required_keys[confidence_interval]} are missing "
             " for confidence interval procedure "
             f"{confidence_interval}."
         )
 
     if not isinstance(confidence_interval_options, dict) or (
-        not all(key in confidence_interval_options for key in required_keys)
+        not all(
+            key in confidence_interval_options
+            for key in required_keys[confidence_interval]
+        )
     ):
         error_report += (
             f"Confidence interval options {confidence_interval_options} is not a dict "
-            f"with required keys {required_keys}."
+            f"with required keys {required_keys[confidence_interval]}."
         )
+
+    # TODO(@buddejul): Checks on the arguments.
+    # Note: Subsapmling should be allowed to be either an integer or a function of n
+    # returning a number.
 
     return error_report
 

--- a/src/pyvmte/utilities.py
+++ b/src/pyvmte/utilities.py
@@ -459,6 +459,29 @@ def _error_report_shape_constraints(shape_constraints: tuple[str, str] | None) -
     return error_report
 
 
+def _error_report_confidence_interval(confidence_interval: str | None) -> str:
+    error_report = ""
+
+    if confidence_interval is None:
+        return error_report
+
+    if not isinstance(confidence_interval, str):
+        return (
+            f"Confidence interval procedure {confidence_interval} is not None"
+            "but not of type str."
+        )
+
+    _supported_procedures = "bootstrap"
+
+    if confidence_interval not in _supported_procedures:
+        error_report += (
+            f"Confidence interval procedure {confidence_interval} is not valid. "
+            f"Only {_supported_procedures} are valid."
+        )
+
+    return error_report
+
+
 def generate_bernstein_basis_funcs(k: int) -> list[dict]:
     """Generate list containing basis functions of kth-oder Bernstein polynomial.
 

--- a/tests/estimation/test_estimation_confidence_interval.py
+++ b/tests/estimation/test_estimation_confidence_interval.py
@@ -17,7 +17,7 @@ sample_size = 10_000
 subsample_size = int(0.1 * sample_size)
 num_sims = 100
 
-inference_methods = ["bootstrap", "subsampling", "recentered_bootstrap"]
+inference_methods = ["bootstrap", "subsampling", "rescaled_bootstrap"]
 
 # This tolerance might be too generous. However, we only run 100 simulations to keep
 # the runtime relatively low so should be fine.

--- a/tests/estimation/test_estimation_confidence_interval.py
+++ b/tests/estimation/test_estimation_confidence_interval.py
@@ -1,5 +1,6 @@
 """Test functions for (bootstrap) confidence intervals."""
 
+import numpy as np
 import pytest
 from pyvmte.classes import Estimand
 from pyvmte.config import RNG
@@ -8,24 +9,31 @@ from pyvmte.utilities import simulate_data_from_simple_model_dgp
 
 
 @pytest.fixture()
-def estimation_setup():
-    dgp_params = {
+def dgp_params():
+    return {
         "y1_at": 1,
         "y0_at": 0,
         "y1_c": 0.5,
         "y0_c": 0,
-        "y1_nt": 0,
+        "y1_nt": 1,  # ensures we are at the upper bound of the identified set
         "y0_nt": 0,
     }
 
+
+@pytest.fixture()
+def estimation_setup(dgp_params):
     data = simulate_data_from_simple_model_dgp(
-        sample_size=1_000,
+        sample_size=10_000,
         rng=RNG,
         dgp_params=dgp_params,
     )
     return {
-        "target": Estimand("late", u_lo=0.4, u_hi=0.6, u_hi_extra=0.2),
-        "identified_estimands": [Estimand("late", u_lo=0.4, u_hi=0.6)],
+        "target": Estimand("late", u_hi_extra=0.2),
+        "identified_estimands": [
+            Estimand(
+                "late",
+            ),
+        ],
         "basis_func_type": "constant",
         "y_data": data["y"],
         "z_data": data["z"],
@@ -43,3 +51,51 @@ def test_estimation_with_confidence_interval_correct_ordering(estimation_setup):
 
     assert res.ci_lower <= res.lower_bound
     assert res.ci_upper >= res.upper_bound
+
+
+def test_ci_right_coverage(estimation_setup, dgp_params):
+    num_sims = 100
+
+    alpha = 0.05
+
+    # Delete the "data" key in estimation_setup
+    for data in ["y_data", "z_data", "d_data"]:
+        estimation_setup.pop(data)
+
+    w = 0.5
+    late_c = dgp_params["y1_c"] - dgp_params["y0_c"]
+    late_nt = dgp_params["y1_nt"] - dgp_params["y0_nt"]
+    true = w * late_c + (1 - w) * late_nt
+
+    sims_ci_lower = np.zeros(num_sims)
+    sims_ci_upper = np.zeros(num_sims)
+
+    for i in range(num_sims):
+        _sim_data = simulate_data_from_simple_model_dgp(
+            sample_size=10_000,
+            rng=RNG,
+            dgp_params=dgp_params,
+        )
+        _res = estimation(
+            **estimation_setup,
+            y_data=_sim_data["y"],
+            z_data=_sim_data["z"],
+            d_data=_sim_data["d"],
+        )
+
+        sims_ci_lower[i] = _res.ci_lower
+        sims_ci_upper[i] = _res.ci_upper
+
+    actual_coverage = np.mean((sims_ci_lower <= true) & (sims_ci_upper >= true))
+
+    actual_coverage_upper = np.mean(sims_ci_upper >= true)
+    actual_coverage_lower = np.mean(sims_ci_lower <= true)
+
+    expected_coverage = 1 - alpha
+    expected_coverage_upper = 1 - alpha
+    expected_coverage_lower = 1
+
+    assert actual_coverage_lower == pytest.approx(expected_coverage_lower, abs=0.02)
+    assert actual_coverage_upper == pytest.approx(expected_coverage_upper, abs=0.02)
+
+    assert actual_coverage == pytest.approx(expected_coverage, abs=0.02)

--- a/tests/estimation/test_estimation_confidence_interval.py
+++ b/tests/estimation/test_estimation_confidence_interval.py
@@ -1,0 +1,38 @@
+"""Test functions for (bootstrap) confidence intervals."""
+
+import pytest
+from pyvmte.classes import Estimand
+from pyvmte.config import RNG
+from pyvmte.estimation import estimation
+from pyvmte.utilities import simulate_data_from_simple_model_dgp
+
+
+@pytest.fixture()
+def estimation_setup():
+    dgp_params = {
+        "y1_at": 1,
+        "y0_at": 0,
+        "y1_c": 0.5,
+        "y0_c": 0,
+        "y1_nt": 0,
+        "y0_nt": 0,
+    }
+
+    data = simulate_data_from_simple_model_dgp(
+        sample_size=1_000,
+        rng=RNG,
+        dgp_params=dgp_params,
+    )
+    return {
+        "target": Estimand("late", u_lo=0.4, u_hi=0.6, u_hi_extra=0.2),
+        "identified_estimands": [Estimand("late", u_lo=0.4, u_hi=0.6)],
+        "basis_func_type": "constant",
+        "y_data": data["y"],
+        "z_data": data["z"],
+        "d_data": data["d"],
+        "confidence_interval": "bootstrap",
+    }
+
+
+def test_estimation_with_confidence_interval_runs(estimation_setup):
+    estimation(**estimation_setup)

--- a/tests/estimation/test_estimation_confidence_interval.py
+++ b/tests/estimation/test_estimation_confidence_interval.py
@@ -7,6 +7,14 @@ from pyvmte.config import RNG
 from pyvmte.estimation import estimation
 from pyvmte.utilities import simulate_data_from_simple_model_dgp
 
+# --------------------------------------------------------------------------------------
+# Parameters for tests
+# --------------------------------------------------------------------------------------
+alpha = 0.05
+n_boot = 100
+sample_size = 1_000
+num_sims = 100
+
 
 @pytest.fixture()
 def dgp_params():
@@ -23,7 +31,7 @@ def dgp_params():
 @pytest.fixture()
 def estimation_setup(dgp_params):
     data = simulate_data_from_simple_model_dgp(
-        sample_size=10_000,
+        sample_size=sample_size,
         rng=RNG,
         dgp_params=dgp_params,
     )
@@ -39,7 +47,13 @@ def estimation_setup(dgp_params):
         "z_data": data["z"],
         "d_data": data["d"],
         "confidence_interval": "bootstrap",
+        "confidence_interval_options": {"n_boot": n_boot, "alpha": alpha},
     }
+
+
+# --------------------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------------------
 
 
 def test_estimation_with_confidence_interval_runs(estimation_setup):
@@ -54,11 +68,6 @@ def test_estimation_with_confidence_interval_correct_ordering(estimation_setup):
 
 
 def test_ci_right_coverage(estimation_setup, dgp_params):
-    num_sims = 100
-
-    alpha = 0.05
-
-    # Delete the "data" key in estimation_setup
     for data in ["y_data", "z_data", "d_data"]:
         estimation_setup.pop(data)
 
@@ -72,7 +81,7 @@ def test_ci_right_coverage(estimation_setup, dgp_params):
 
     for i in range(num_sims):
         _sim_data = simulate_data_from_simple_model_dgp(
-            sample_size=10_000,
+            sample_size=sample_size,
             rng=RNG,
             dgp_params=dgp_params,
         )

--- a/tests/estimation/test_estimation_confidence_interval.py
+++ b/tests/estimation/test_estimation_confidence_interval.py
@@ -11,13 +11,17 @@ from pyvmte.utilities import simulate_data_from_simple_model_dgp
 # Parameters for tests
 # --------------------------------------------------------------------------------------
 alpha = 0.1
-n_boot = 250
+n_boot = 1_000
 n_subsamples = n_boot
-sample_size = 1_000
-subsample_size = int(np.floor(np.sqrt(sample_size)))
+sample_size = 10_000
+subsample_size = int(0.1 * sample_size)
 num_sims = 100
 
-inference_methods = ["subsampling", "recentered_bootstrap"]
+inference_methods = ["bootstrap", "subsampling", "recentered_bootstrap"]
+
+# This tolerance might be too generous. However, we only run 100 simulations to keep
+# the runtime relatively low so should be fine.
+ATOL = 0.05
 
 
 @pytest.fixture()
@@ -128,7 +132,7 @@ def test_ci_right_coverage(
     expected_coverage_upper = 1 - alpha
     expected_coverage_lower = 1
 
-    assert actual_coverage_lower == pytest.approx(expected_coverage_lower, abs=0.02)
-    assert actual_coverage_upper == pytest.approx(expected_coverage_upper, abs=0.02)
+    assert actual_coverage_lower == pytest.approx(expected_coverage_lower, abs=ATOL)
+    assert actual_coverage_upper == pytest.approx(expected_coverage_upper, abs=ATOL)
 
-    assert actual_coverage == pytest.approx(expected_coverage, abs=0.02)
+    assert actual_coverage == pytest.approx(expected_coverage, abs=ATOL)

--- a/tests/estimation/test_estimation_confidence_interval.py
+++ b/tests/estimation/test_estimation_confidence_interval.py
@@ -11,13 +11,13 @@ from pyvmte.utilities import simulate_data_from_simple_model_dgp
 # Parameters for tests
 # --------------------------------------------------------------------------------------
 alpha = 0.1
-n_boot = 100
+n_boot = 250
 n_subsamples = n_boot
 sample_size = 1_000
 subsample_size = int(np.floor(np.sqrt(sample_size)))
 num_sims = 100
 
-inference_methods = ["bootstrap", "subsampling", "recentered_bootstrap"]
+inference_methods = ["subsampling", "recentered_bootstrap"]
 
 
 @pytest.fixture()

--- a/tests/estimation/test_estimation_confidence_interval.py
+++ b/tests/estimation/test_estimation_confidence_interval.py
@@ -36,3 +36,10 @@ def estimation_setup():
 
 def test_estimation_with_confidence_interval_runs(estimation_setup):
     estimation(**estimation_setup)
+
+
+def test_estimation_with_confidence_interval_correct_ordering(estimation_setup):
+    res = estimation(**estimation_setup)
+
+    assert res.ci_lower <= res.lower_bound
+    assert res.ci_upper >= res.upper_bound

--- a/tests/utilities/test_error_reports.py
+++ b/tests/utilities/test_error_reports.py
@@ -418,12 +418,12 @@ def test_error_report_mte_monotone():
 
 
 def test_error_report_confidence_interval():
-    invalid_args = ["subsampling", "numerical_delta", "analytical_delta", 1, True]
+    invalid_args = ["numerical_delta", "analytical_delta", 1, True]
 
     for arg in invalid_args:
         assert _error_report_confidence_interval(arg) != ""
 
-    valid_args = [None, "bootstrap"]
+    valid_args = [None, "bootstrap", "subsampling", "rescaled_bootstrap"]
 
     for arg in valid_args:
         assert _error_report_confidence_interval(arg) == ""

--- a/tests/utilities/test_error_reports.py
+++ b/tests/utilities/test_error_reports.py
@@ -5,6 +5,7 @@ from pyvmte.estimation import estimation
 from pyvmte.identification import identification
 from pyvmte.utilities import (
     _error_report_basis_funcs,
+    _error_report_confidence_interval,
     _error_report_estimand,
     _error_report_estimation_data,
     _error_report_instrument,
@@ -126,6 +127,7 @@ def valid_input():
         "tolerance": 0.1,
         "u_partition": np.array([0, 0.35, 0.65, 0.7, 1]),
         "method": "highs",
+        "confidence_interval": None,
     }
 
 
@@ -165,6 +167,9 @@ def valid_input():
         {"identified_estimands": Estimand(esttype="late", u_lo=0.5, u_hi="daslk")},  # type: ignore
         {"identified_estimands": Estimand(esttype="late", u_lo=0.5, u_hi=0.2)},
         {"identified_estimands": Estimand(esttype="late", u_lo=1.2, u_hi=1.4)},
+        ({"confidence_interval": "not valid"}),
+        ({"confidence_interval": True}),
+        ({"confidence_interval": 1}),
     ],
 )
 def test_estimation_invalid_input(valid_input, invalid_input):
@@ -410,3 +415,15 @@ def test_error_report_mte_monotone():
 
     for value in [None, "increasing", "decreasing"]:
         assert _error_report_mte_monotone(value) == ""
+
+
+def test_error_report_confidence_interval():
+    invalid_args = ["subsampling", "numerical_delta", "analytical_delta", 1, True]
+
+    for arg in invalid_args:
+        assert _error_report_confidence_interval(arg) != ""
+
+    valid_args = [None, "bootstrap"]
+
+    for arg in valid_args:
+        assert _error_report_confidence_interval(arg) == ""


### PR DESCRIPTION
#### Changes

Preliminary implementation of inference in the form of confidence intervals using three resampling procedures:
- Standard, non-parametric bootstrap: Size `m=n` samples with replacement
- Rescaled or m-out-of-n bootstrap: Size `m<n` samples with replacement
- Subsampling: Size `m<n` samples without replacement

These are implemented in the `estimation` call and by recursively calling the function on the resamples samples.

Adresses #46 